### PR TITLE
Add semi-service package option and adjust pricing

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,12 +28,48 @@ STEP7_IMAGE = os.getenv("STEP7_IMAGE", "").strip()
 
 # Package prices in DEFAULT_CURRENCY
 PACKAGES = {
-    "template": 299,
-    "full": 999,
+    "template": 300,
+    "semi": 500,
+    "full": 800,
 }
 
-# Discounted price for upgrading from template to full package
-UPGRADE_FULL_PRICE = 699
+# Package ordering and status mapping
+PACKAGE_ORDER = ["template", "semi", "full"]
+PACKAGE_STATUSES = {
+    "template": "Middle Tier",
+    "semi": "Semi Tier",
+    "full": "High Tier",
+}
+STATUS_TO_PACKAGE = {status: package for package, status in PACKAGE_STATUSES.items()}
+
+# Upgrade price differences between tiers
+UPGRADE_PRICES = {
+    ("template", "semi"): PACKAGES["semi"] - PACKAGES["template"],
+    ("template", "full"): PACKAGES["full"] - PACKAGES["template"],
+    ("semi", "full"): PACKAGES["full"] - PACKAGES["semi"],
+}
+
+
+def get_package_price(item: str, status: str) -> float:
+    """Return the payable amount for a package based on current status."""
+
+    if item not in PACKAGES:
+        raise KeyError(f"Unknown package: {item}")
+
+    current_package = STATUS_TO_PACKAGE.get(status)
+    if not current_package:
+        return PACKAGES[item]
+
+    try:
+        current_index = PACKAGE_ORDER.index(current_package)
+        target_index = PACKAGE_ORDER.index(item)
+    except ValueError:
+        return PACKAGES[item]
+
+    if target_index > current_index:
+        return UPGRADE_PRICES.get((current_package, item), PACKAGES[item])
+
+    raise ValueError("Package not available for the current status")
 
 # RDP package prices in DEFAULT_CURRENCY
 RDP_PACKAGES = {

--- a/keyboards.py
+++ b/keyboards.py
@@ -3,9 +3,10 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from config import (
     SUPPORT_USERNAME,
     DEFAULT_CURRENCY,
-    PACKAGES,
     RDP_PACKAGES,
-    UPGRADE_FULL_PRICE,
+    PACKAGE_ORDER,
+    STATUS_TO_PACKAGE,
+    get_package_price,
 )
 from texts import T
 from typing import Optional, List, Tuple
@@ -84,22 +85,30 @@ def setup_complete_keyboard(lang: str):
 def purchase_keyboard(lang: str, status: str):
     cur = DEFAULT_CURRENCY
     kb = InlineKeyboardMarkup(row_width=1)
-    if status != "Middle Tier":
+
+    current_package = STATUS_TO_PACKAGE.get(status)
+    try:
+        current_index = PACKAGE_ORDER.index(current_package) if current_package else -1
+    except ValueError:
+        current_index = -1
+
+    label_map = {
+        "template": "purchase_template",
+        "semi": "purchase_semi",
+        "full": "purchase_full",
+    }
+
+    for idx, package in enumerate(PACKAGE_ORDER):
+        if idx <= current_index:
+            continue
+        price = get_package_price(package, status)
         kb.add(
             InlineKeyboardButton(
-                T[lang]["purchase_template"].format(
-                    price=PACKAGES["template"], cur=cur
-                ),
-                callback_data="purchase:template",
+                T[lang][label_map[package]].format(price=price, cur=cur),
+                callback_data=f"purchase:{package}",
             )
         )
-    price_full = UPGRADE_FULL_PRICE if status == "Middle Tier" else PACKAGES["full"]
-    kb.add(
-        InlineKeyboardButton(
-            T[lang]["purchase_full"].format(price=price_full, cur=cur),
-            callback_data="purchase:full",
-        )
-    )
+
     kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
     return kb
 

--- a/main.py
+++ b/main.py
@@ -12,9 +12,7 @@ from aiohttp import web
 import qrcode
 from config import (
     BOT_TOKEN,
-    PACKAGES,
     RDP_PACKAGES,
-    UPGRADE_FULL_PRICE,
     ADMIN_ID,
     STEP1_IMAGE,
     STEP2_IMAGE,
@@ -23,6 +21,8 @@ from config import (
     STEP5_IMAGE,
     STEP6_IMAGE,
     STEP7_IMAGE,
+    PACKAGE_STATUSES,
+    get_package_price,
 )
 from database import Database
 from keyboards import (
@@ -57,6 +57,7 @@ dp = Dispatcher(bot, storage=MemoryStorage())
 history = defaultdict(list)
 qr_messages = {}
 init_payments(bot, db, qr_messages)
+FULL_STATUS = PACKAGE_STATUSES["full"]
 
 
 class AdminStates(StatesGroup):
@@ -118,7 +119,7 @@ async def cmd_start(message: types.Message):
         reply_markup=main_menu_keyboard(
             lang,
             is_admin=user.id == ADMIN_ID,
-            show_purchase=status != "High Tier",
+            show_purchase=status != FULL_STATUS,
         ),
     )
 
@@ -138,7 +139,7 @@ async def cb_set_language(call: types.CallbackQuery):
         reply_markup=main_menu_keyboard(
             lang,
             is_admin=user.id == ADMIN_ID,
-            show_purchase=status != "High Tier",
+            show_purchase=status != FULL_STATUS,
         ),
     )
 
@@ -156,7 +157,7 @@ async def cb_purchase(call: types.CallbackQuery):
     lang = db.get_language(user_id)
     history[user_id].append((call.message.text or "", call.message.reply_markup))
     status = db.get_status(user_id)
-    if status == "High Tier":
+    if status == FULL_STATUS:
         await call.message.edit_text(
             T[lang]["purchase_unavailable"], reply_markup=back_to_menu(lang)
         )
@@ -541,7 +542,7 @@ async def cb_topup_cancel(call: types.CallbackQuery, state: FSMContext):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 
@@ -791,10 +792,12 @@ async def cb_purchase_item(call: types.CallbackQuery):
     lang = db.get_language(call.from_user.id)
     history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
     item = call.data.split(":")[1]
-    if item == "template":
-        msg = T[lang]["desc_template"]
-    else:
-        msg = T[lang]["desc_full"]
+    desc_map = {
+        "template": "desc_template",
+        "semi": "desc_semi",
+        "full": "desc_full",
+    }
+    msg = T[lang][desc_map.get(item, "desc_full")]
     await call.message.edit_text(msg, reply_markup=purchase_item_keyboard(lang, item))
 
 
@@ -817,15 +820,17 @@ async def cb_pay(call: types.CallbackQuery):
 
     status = db.get_status(user_id)
     if currency == "BAL":
-        if item == "full" and status == "Middle Tier":
-            price = UPGRADE_FULL_PRICE
-        else:
-            price = PACKAGES[item]
+        try:
+            price = get_package_price(item, status)
+        except (KeyError, ValueError):
+            await call.answer(T[lang]["purchase_unavailable"], show_alert=True)
+            return
+
         if db.deduct_balance(user_id, price):
-            tier_map = {"template": "Middle Tier", "full": "High Tier"}
-            new_status = tier_map.get(item)
-            if new_status:
+            new_status = PACKAGE_STATUSES.get(item)
+            if new_status and new_status != status:
                 db.set_status(user_id, new_status)
+                db.set_config_seen(user_id, False)
             await call.message.edit_text(
                 T[lang]["purchase_success"], reply_markup=back_to_menu(lang)
             )
@@ -848,10 +853,11 @@ async def cb_pay(call: types.CallbackQuery):
         order_id = f"{item}-{user_id}-{int(datetime.utcnow().timestamp())}"
         description = item
     else:
-        if item == "full" and status == "Middle Tier":
-            price = UPGRADE_FULL_PRICE
-        else:
-            price = PACKAGES[item]
+        try:
+            price = get_package_price(item, status)
+        except (KeyError, ValueError):
+            await call.answer(T[lang]["purchase_unavailable"], show_alert=True)
+            return
         order_id = f"{item}-{user_id}-{int(datetime.utcnow().timestamp())}"
         description = item
 
@@ -909,7 +915,7 @@ async def cb_back(call: types.CallbackQuery):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 
@@ -948,7 +954,7 @@ async def cb_cancel(call: types.CallbackQuery):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 

--- a/payments.py
+++ b/payments.py
@@ -7,6 +7,7 @@ from config import (
     NOWPAYMENTS_IPN_URL,
     DEFAULT_CURRENCY,
     ADMIN_ID,
+    PACKAGE_STATUSES,
 )
 from texts import T
 from database import Database
@@ -62,7 +63,7 @@ async def ipn_handler(request: web.Request):
     except ValueError:
         return web.Response(text="OK")
 
-    tier_map = {"template": "Middle Tier", "full": "High Tier"}
+    tier_map = PACKAGE_STATUSES
     rdp_map = {"rdp1": "1 month", "rdp2": "2 months", "rdp3": "3 months"}
     new_status = tier_map.get(item)
     if new_status:

--- a/steps.env
+++ b/steps.env
@@ -1,7 +1,7 @@
-STEP1_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/1.mp4
-STEP2_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/2.mp4
-STEP3_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/3.mp4
-STEP4_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/4.mp4
-STEP5_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/5.mp4
-STEP6_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/6.mp4
-STEP7_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/7.mp4
+STEP1_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/1.mp4
+STEP2_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/2.mp4
+STEP3_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/3.mp4
+STEP4_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/4.mp4
+STEP5_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/5.mp4
+STEP6_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/6.mp4
+STEP7_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/7.mp4

--- a/texts.py
+++ b/texts.py
@@ -16,6 +16,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Language",
         "purchase_title": "🛍️ *Choose a package:*",
         "purchase_template": "📦 Template bot ({price} {cur})",
+        "purchase_semi": "⚡ Semi-service bot ({price} {cur})",
         "purchase_full": "🚀 Full-service bot ({price} {cur})",
         "desc_template": (
             "🟢 *Template Bot*\n"
@@ -25,6 +26,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Discount codes*\n"
             "• 📣 *Mass messaging*\n"
             "• 👥 *User stats & management*\n\n"
+            "🕘 *Runs 24/7 with no extra fees* (hosting: 10 EUR/month)."
+        ),
+        "desc_semi": (
+            "🟡 *Semi-Service Bot*\n"
+            "• ⚙️ *Real-time feature adjustments*\n"
+            "• 🔄 *Regular updates included*\n"
+            "• ➕ *Add one new custom feature every month*\n"
+            "• 📊 *Advanced shop controls*\n\n"
             "🕘 *Runs 24/7 with no extra fees* (hosting: 10 EUR/month)."
         ),
         "desc_full": (
@@ -50,7 +59,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Pay with balance",
         "insufficient_balance": "❌ Insufficient balance. Please top up.",
         "purchase_success": "✅ Payment received! Go to *Config* to set up your bot.",
-        "purchase_unavailable": "✅ You already own the full package.",
+        "purchase_unavailable": "✅ You already own this package or a higher tier.",
         "config_first_time": (
             "🎉 *Welcome to settings!*\n"
             "It's your first time here. Tap *Set Up* below to configure your bot or contact support."
@@ -153,6 +162,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Язык",
         "purchase_title": "🛍️ *Выберите пакет:*",
         "purchase_template": "📦 Шаблон-бот ({price} {cur})",
+        "purchase_semi": "⚡ Бот с частичным сервисом ({price} {cur})",
         "purchase_full": "🚀 Полный сервис-бот ({price} {cur})",
         "desc_template": (
             "🟢 *Шаблон-бот*\n"
@@ -162,6 +172,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Промокоды*\n"
             "• 📣 *Рассылки*\n"
             "• 👥 *Статистика и управление пользователями*\n\n"
+            "🕘 *Работает 24/7 без доп. оплат* (хостинг: 10 EUR/мес)."
+        ),
+        "desc_semi": (
+            "🟡 *Бот с частичным сервисом*\n"
+            "• ⚙️ *Меняйте функции в реальном времени*\n"
+            "• 🔄 *Регулярные обновления включены*\n"
+            "• ➕ *Добавление одной новой функции каждый месяц*\n"
+            "• 📊 *Расширенные инструменты управления*\n\n"
             "🕘 *Работает 24/7 без доп. оплат* (хостинг: 10 EUR/мес)."
         ),
         "desc_full": (
@@ -187,7 +205,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Оплатить с баланса",
         "insufficient_balance": "❌ Недостаточно средств. Пополните баланс.",
         "purchase_success": "✅ Оплата получена! Перейдите в *Настройки*, чтобы настроить бота.",
-        "purchase_unavailable": "✅ Вы уже приобрели полный пакет.",
+        "purchase_unavailable": "✅ Этот пакет уже приобретён или у вас есть более высокий уровень.",
         "config_first_time": (
             "🎉 *Добро пожаловать в настройки!*\n"
             "Вы здесь впервые. Нажмите *Настроить*, чтобы сконфигурировать бота или обратитесь в поддержку."
@@ -290,6 +308,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Kalba",
         "purchase_title": "🛍️ *Pasirinkite paketą:*",
         "purchase_template": "📦 Šabloninis botas ({price} {cur})",
+        "purchase_semi": "⚡ Dalinio aptarnavimo botas ({price} {cur})",
         "purchase_full": "🚀 Pilno aptarnavimo botas ({price} {cur})",
         "desc_template": (
             "🟢 *Šabloninis botas*\n"
@@ -299,6 +318,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Nuolaidų kodai*\n"
             "• 📣 *Masiniai pranešimai*\n"
             "• 👥 *Vartotojų statistika ir valdymas*\n\n"
+            "🕘 *Veikia 24/7 be papildomų mokesčių* (hostingas: 10 EUR/mėn)."
+        ),
+        "desc_semi": (
+            "🟡 *Dalinio aptarnavimo botas*\n"
+            "• ⚙️ *Keiskite funkcijas realiu laiku*\n"
+            "• 🔄 *Reguliarūs atnaujinimai įskaičiuoti*\n"
+            "• ➕ *Kiekvieną mėnesį pridėkite po vieną naują funkciją*\n"
+            "• 📊 *Pažangūs parduotuvės įrankiai*\n\n"
             "🕘 *Veikia 24/7 be papildomų mokesčių* (hostingas: 10 EUR/mėn)."
         ),
         "desc_full": (
@@ -324,7 +351,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Mokėti iš balanso",
         "insufficient_balance": "❌ Nepakanka lėšų. Papildykite balansą.",
         "purchase_success": "✅ Mokėjimas gautas! Eikite į *Nustatymai* ir sukonfigūruokite botą.",
-        "purchase_unavailable": "✅ Jau turite pilną paketą.",
+        "purchase_unavailable": "✅ Jūs jau turite šį paketą arba aukštesnį lygį.",
         "config_first_time": (
             "🎉 *Sveiki atvykę į nustatymus!*\n"
             "Jūs čia pirmą kartą. Paspauskite *Nustatyti*, kad sukonfigūruotumėte botą arba susisiekite su pagalba."


### PR DESCRIPTION
## Summary
- update package metadata to include a semi-service tier with helper pricing logic
- refresh purchase flows, payment handling, and translations to surface the new option in three languages
- point setup step media paths at the og/steps directory provided by the user

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d86d3ed7608332821e6e1b5dfe061d