### PR TITLE
Add functions submenu and feature descriptions

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,12 +28,48 @@ STEP7_IMAGE = os.getenv("STEP7_IMAGE", "").strip()
 
 # Package prices in DEFAULT_CURRENCY
 PACKAGES = {
-    "template": 299,
-    "full": 999,
+    "template": 300,
+    "semi": 500,
+    "full": 800,
 }
 
-# Discounted price for upgrading from template to full package
-UPGRADE_FULL_PRICE = 699
+# Package ordering and status mapping
+PACKAGE_ORDER = ["template", "semi", "full"]
+PACKAGE_STATUSES = {
+    "template": "Middle Tier",
+    "semi": "Semi Tier",
+    "full": "High Tier",
+}
+STATUS_TO_PACKAGE = {status: package for package, status in PACKAGE_STATUSES.items()}
+
+# Upgrade price differences between tiers
+UPGRADE_PRICES = {
+    ("template", "semi"): PACKAGES["semi"] - PACKAGES["template"],
+    ("template", "full"): PACKAGES["full"] - PACKAGES["template"],
+    ("semi", "full"): PACKAGES["full"] - PACKAGES["semi"],
+}
+
+
+def get_package_price(item: str, status: str) -> float:
+    """Return the payable amount for a package based on current status."""
+
+    if item not in PACKAGES:
+        raise KeyError(f"Unknown package: {item}")
+
+    current_package = STATUS_TO_PACKAGE.get(status)
+    if not current_package:
+        return PACKAGES[item]
+
+    try:
+        current_index = PACKAGE_ORDER.index(current_package)
+        target_index = PACKAGE_ORDER.index(item)
+    except ValueError:
+        return PACKAGES[item]
+
+    if target_index > current_index:
+        return UPGRADE_PRICES.get((current_package, item), PACKAGES[item])
+
+    raise ValueError("Package not available for the current status")
 
 # RDP package prices in DEFAULT_CURRENCY
 RDP_PACKAGES = {

--- a/keyboards.py
+++ b/keyboards.py
@@ -3,9 +3,10 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from config import (
     SUPPORT_USERNAME,
     DEFAULT_CURRENCY,
-    PACKAGES,
     RDP_PACKAGES,
-    UPGRADE_FULL_PRICE,
+    PACKAGE_ORDER,
+    STATUS_TO_PACKAGE,
+    get_package_price,
 )
 from texts import T
 from typing import Optional, List, Tuple
@@ -51,6 +52,7 @@ def config_keyboard(lang: str, setup_done: bool):
         kb.add(InlineKeyboardButton(T[lang]["config_rdp"], callback_data="config:rdp"))
     else:
         kb.add(InlineKeyboardButton(T[lang]["config_setup"], callback_data="config:setup"))
+    kb.add(InlineKeyboardButton(T[lang]["config_functions"], callback_data="config:functions"))
     kb.add(
         InlineKeyboardButton(
             T[lang]["config_support"], url=f"https://t.me/{SUPPORT_USERNAME}"
@@ -58,6 +60,70 @@ def config_keyboard(lang: str, setup_done: bool):
     )
     kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
     return kb
+
+
+def functions_menu_keyboard(lang: str):
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(
+        InlineKeyboardButton(
+            T[lang]["functions_protection"], callback_data="functions:protection"
+        )
+    )
+    kb.add(
+        InlineKeyboardButton(T[lang]["functions_admin"], callback_data="functions:admin")
+    )
+    kb.add(
+        InlineKeyboardButton(T[lang]["functions_user"], callback_data="functions:user")
+    )
+    kb.add(
+        InlineKeyboardButton(
+            T[lang]["functions_payments"], callback_data="functions:payments"
+        )
+    )
+    kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
+    return kb
+
+
+def functions_protection_keyboard(lang: str):
+    return InlineKeyboardMarkup(row_width=1).add(
+        InlineKeyboardButton(
+            T[lang]["feature_anti_spam"], callback_data="feature:anti_spam"
+        ),
+        InlineKeyboardButton(T[lang]["back"], callback_data="back"),
+    )
+
+
+def functions_admin_keyboard(lang: str):
+    return InlineKeyboardMarkup(row_width=1).add(
+        InlineKeyboardButton(
+            T[lang]["feature_assistant_management"],
+            callback_data="feature:assistant_management",
+        ),
+        InlineKeyboardButton(T[lang]["back"], callback_data="back"),
+    )
+
+
+def functions_user_keyboard(lang: str):
+    kb = InlineKeyboardMarkup(row_width=1)
+    kb.add(
+        InlineKeyboardButton(
+            T[lang]["feature_user_levels"], callback_data="feature:user_levels"
+        )
+    )
+    kb.add(
+        InlineKeyboardButton(
+            T[lang]["feature_stock_notifications"],
+            callback_data="feature:stock_notifications",
+        )
+    )
+    kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
+    return kb
+
+
+def functions_payments_keyboard(lang: str):
+    return InlineKeyboardMarkup(row_width=1).add(
+        InlineKeyboardButton(T[lang]["back"], callback_data="back"),
+    )
 
 
 def setup_next_keyboard(lang: str, next_cb: str):
@@ -84,22 +150,30 @@ def setup_complete_keyboard(lang: str):
 def purchase_keyboard(lang: str, status: str):
     cur = DEFAULT_CURRENCY
     kb = InlineKeyboardMarkup(row_width=1)
-    if status != "Middle Tier":
+
+    current_package = STATUS_TO_PACKAGE.get(status)
+    try:
+        current_index = PACKAGE_ORDER.index(current_package) if current_package else -1
+    except ValueError:
+        current_index = -1
+
+    label_map = {
+        "template": "purchase_template",
+        "semi": "purchase_semi",
+        "full": "purchase_full",
+    }
+
+    for idx, package in enumerate(PACKAGE_ORDER):
+        if idx <= current_index:
+            continue
+        price = get_package_price(package, status)
         kb.add(
             InlineKeyboardButton(
-                T[lang]["purchase_template"].format(
-                    price=PACKAGES["template"], cur=cur
-                ),
-                callback_data="purchase:template",
+                T[lang][label_map[package]].format(price=price, cur=cur),
+                callback_data=f"purchase:{package}",
             )
         )
-    price_full = UPGRADE_FULL_PRICE if status == "Middle Tier" else PACKAGES["full"]
-    kb.add(
-        InlineKeyboardButton(
-            T[lang]["purchase_full"].format(price=price_full, cur=cur),
-            callback_data="purchase:full",
-        )
-    )
+
     kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
     return kb
 

--- a/main.py
+++ b/main.py
@@ -12,9 +12,7 @@ from aiohttp import web
 import qrcode
 from config import (
     BOT_TOKEN,
-    PACKAGES,
     RDP_PACKAGES,
-    UPGRADE_FULL_PRICE,
     ADMIN_ID,
     STEP1_IMAGE,
     STEP2_IMAGE,
@@ -23,6 +21,8 @@ from config import (
     STEP5_IMAGE,
     STEP6_IMAGE,
     STEP7_IMAGE,
+    PACKAGE_STATUSES,
+    get_package_price,
 )
 from database import Database
 from keyboards import (
@@ -36,6 +36,11 @@ from keyboards import (
     admin_panel_keyboard,
     user_profile_keyboard,
     config_keyboard,
+    functions_menu_keyboard,
+    functions_protection_keyboard,
+    functions_admin_keyboard,
+    functions_user_keyboard,
+    functions_payments_keyboard,
     rdp_keyboard,
     setup_next_keyboard,
     setup_cancel_keyboard,
@@ -57,6 +62,7 @@ dp = Dispatcher(bot, storage=MemoryStorage())
 history = defaultdict(list)
 qr_messages = {}
 init_payments(bot, db, qr_messages)
+FULL_STATUS = PACKAGE_STATUSES["full"]
 
 
 class AdminStates(StatesGroup):
@@ -118,7 +124,7 @@ async def cmd_start(message: types.Message):
         reply_markup=main_menu_keyboard(
             lang,
             is_admin=user.id == ADMIN_ID,
-            show_purchase=status != "High Tier",
+            show_purchase=status != FULL_STATUS,
         ),
     )
 
@@ -138,7 +144,7 @@ async def cb_set_language(call: types.CallbackQuery):
         reply_markup=main_menu_keyboard(
             lang,
             is_admin=user.id == ADMIN_ID,
-            show_purchase=status != "High Tier",
+            show_purchase=status != FULL_STATUS,
         ),
     )
 
@@ -156,7 +162,7 @@ async def cb_purchase(call: types.CallbackQuery):
     lang = db.get_language(user_id)
     history[user_id].append((call.message.text or "", call.message.reply_markup))
     status = db.get_status(user_id)
-    if status == "High Tier":
+    if status == FULL_STATUS:
         await call.message.edit_text(
             T[lang]["purchase_unavailable"], reply_markup=back_to_menu(lang)
         )
@@ -185,6 +191,92 @@ async def cb_config(call: types.CallbackQuery):
         text = T[lang]["config_title"]
     setup_done = db.get_setup_done(call.from_user.id)
     await call.message.edit_text(text, reply_markup=config_keyboard(lang, setup_done))
+
+
+@dp.callback_query_handler(lambda c: c.data == "config:functions")
+async def cb_config_functions(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["functions_title"], reply_markup=functions_menu_keyboard(lang)
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "functions:protection")
+async def cb_functions_protection(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["functions_protection_desc"],
+        reply_markup=functions_protection_keyboard(lang),
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "functions:admin")
+async def cb_functions_admin(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["functions_admin_desc"],
+        reply_markup=functions_admin_keyboard(lang),
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "functions:user")
+async def cb_functions_user(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["functions_user_desc"],
+        reply_markup=functions_user_keyboard(lang),
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "functions:payments")
+async def cb_functions_payments(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["functions_payments_desc"],
+        reply_markup=functions_payments_keyboard(lang),
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "feature:anti_spam")
+async def cb_feature_anti_spam(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["feature_anti_spam_desc"], reply_markup=back_to_menu(lang)
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "feature:assistant_management")
+async def cb_feature_assistant(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["feature_assistant_management_desc"], reply_markup=back_to_menu(lang)
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "feature:user_levels")
+async def cb_feature_user_levels(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["feature_user_levels_desc"], reply_markup=back_to_menu(lang)
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "feature:stock_notifications")
+async def cb_feature_stock_notifications(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    await call.message.edit_text(
+        T[lang]["feature_stock_notifications_desc"],
+        reply_markup=back_to_menu(lang),
+    )
 
 
 @dp.callback_query_handler(lambda c: c.data == "config:rdp")
@@ -541,7 +633,7 @@ async def cb_topup_cancel(call: types.CallbackQuery, state: FSMContext):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 
@@ -791,10 +883,12 @@ async def cb_purchase_item(call: types.CallbackQuery):
     lang = db.get_language(call.from_user.id)
     history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
     item = call.data.split(":")[1]
-    if item == "template":
-        msg = T[lang]["desc_template"]
-    else:
-        msg = T[lang]["desc_full"]
+    desc_map = {
+        "template": "desc_template",
+        "semi": "desc_semi",
+        "full": "desc_full",
+    }
+    msg = T[lang][desc_map.get(item, "desc_full")]
     await call.message.edit_text(msg, reply_markup=purchase_item_keyboard(lang, item))
 
 
@@ -817,15 +911,17 @@ async def cb_pay(call: types.CallbackQuery):
 
     status = db.get_status(user_id)
     if currency == "BAL":
-        if item == "full" and status == "Middle Tier":
-            price = UPGRADE_FULL_PRICE
-        else:
-            price = PACKAGES[item]
+        try:
+            price = get_package_price(item, status)
+        except (KeyError, ValueError):
+            await call.answer(T[lang]["purchase_unavailable"], show_alert=True)
+            return
+
         if db.deduct_balance(user_id, price):
-            tier_map = {"template": "Middle Tier", "full": "High Tier"}
-            new_status = tier_map.get(item)
-            if new_status:
+            new_status = PACKAGE_STATUSES.get(item)
+            if new_status and new_status != status:
                 db.set_status(user_id, new_status)
+                db.set_config_seen(user_id, False)
             await call.message.edit_text(
                 T[lang]["purchase_success"], reply_markup=back_to_menu(lang)
             )
@@ -848,10 +944,11 @@ async def cb_pay(call: types.CallbackQuery):
         order_id = f"{item}-{user_id}-{int(datetime.utcnow().timestamp())}"
         description = item
     else:
-        if item == "full" and status == "Middle Tier":
-            price = UPGRADE_FULL_PRICE
-        else:
-            price = PACKAGES[item]
+        try:
+            price = get_package_price(item, status)
+        except (KeyError, ValueError):
+            await call.answer(T[lang]["purchase_unavailable"], show_alert=True)
+            return
         order_id = f"{item}-{user_id}-{int(datetime.utcnow().timestamp())}"
         description = item
 
@@ -909,7 +1006,7 @@ async def cb_back(call: types.CallbackQuery):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 
@@ -948,7 +1045,7 @@ async def cb_cancel(call: types.CallbackQuery):
             reply_markup=main_menu_keyboard(
                 lang,
                 is_admin=user_id == ADMIN_ID,
-                show_purchase=status != "High Tier",
+                show_purchase=status != FULL_STATUS,
             ),
         )
 

--- a/payments.py
+++ b/payments.py
@@ -7,6 +7,7 @@ from config import (
     NOWPAYMENTS_IPN_URL,
     DEFAULT_CURRENCY,
     ADMIN_ID,
+    PACKAGE_STATUSES,
 )
 from texts import T
 from database import Database
@@ -62,7 +63,7 @@ async def ipn_handler(request: web.Request):
     except ValueError:
         return web.Response(text="OK")
 
-    tier_map = {"template": "Middle Tier", "full": "High Tier"}
+    tier_map = PACKAGE_STATUSES
     rdp_map = {"rdp1": "1 month", "rdp2": "2 months", "rdp3": "3 months"}
     new_status = tier_map.get(item)
     if new_status:

--- a/steps.env
+++ b/steps.env
@@ -1,7 +1,7 @@
-STEP1_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/1.mp4
-STEP2_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/2.mp4
-STEP3_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/3.mp4
-STEP4_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/4.mp4
-STEP5_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/5.mp4
-STEP6_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/6.mp4
-STEP7_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/steps/7.mp4
+STEP1_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/1.mp4
+STEP2_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/2.mp4
+STEP3_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/3.mp4
+STEP4_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/4.mp4
+STEP5_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/5.mp4
+STEP6_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/6.mp4
+STEP7_IMAGE=C:/Users/eriku/Desktop/Botai2025/Projektas_Botas_Shopas/og/steps/7.mp4

--- a/texts.py
+++ b/texts.py
@@ -16,6 +16,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Language",
         "purchase_title": "🛍️ *Choose a package:*",
         "purchase_template": "📦 Template bot ({price} {cur})",
+        "purchase_semi": "⚡ Semi-service bot ({price} {cur})",
         "purchase_full": "🚀 Full-service bot ({price} {cur})",
         "desc_template": (
             "🟢 *Template Bot*\n"
@@ -25,6 +26,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Discount codes*\n"
             "• 📣 *Mass messaging*\n"
             "• 👥 *User stats & management*\n\n"
+            "🕘 *Runs 24/7 with no extra fees* (hosting: 10 EUR/month)."
+        ),
+        "desc_semi": (
+            "🟡 *Semi-Service Bot*\n"
+            "• ⚙️ *Real-time feature adjustments*\n"
+            "• 🔄 *Regular updates included*\n"
+            "• ➕ *Add one new custom feature every month*\n"
+            "• 📊 *Advanced shop controls*\n\n"
             "🕘 *Runs 24/7 with no extra fees* (hosting: 10 EUR/month)."
         ),
         "desc_full": (
@@ -50,7 +59,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Pay with balance",
         "insufficient_balance": "❌ Insufficient balance. Please top up.",
         "purchase_success": "✅ Payment received! Go to *Config* to set up your bot.",
-        "purchase_unavailable": "✅ You already own the full package.",
+        "purchase_unavailable": "✅ You already own this package or a higher tier.",
         "config_first_time": (
             "🎉 *Welcome to settings!*\n"
             "It's your first time here. Tap *Set Up* below to configure your bot or contact support."
@@ -59,7 +68,40 @@ T: Dict[str, Dict[str, str]] = {
         "config_no_status": "🛑 *Purchase a bot to access settings.*",
         "config_setup": "🛠 Set Up",
         "config_rdp": "🖥 RDP",
+        "config_functions": "🧩 Functions",
         "config_support": "🆘 Support",
+        "functions_title": "🧩 *Choose a function category:*",
+        "functions_protection": "🛡 Protection & utilities",
+        "functions_admin": "🧑‍💼 Admin-side features",
+        "functions_user": "👥 User-side features",
+        "functions_payments": "💳 Payments",
+        "functions_protection_desc": "🛡 *Protection & utilities*\nPick a tool below to see what it covers.",
+        "functions_admin_desc": "🧑‍💼 *Admin-side features*\nTap an option to learn how it helps you run the shop.",
+        "functions_user_desc": "👥 *User-side features*\nChoose a feature to see the customer experience upgrades.",
+        "functions_payments_desc": (
+            "💳 *Payments*\n"
+            "Accept secure crypto payments via NOWPayments with automatic confirmations for SOL, USDT-TRC20, and XMR."
+        ),
+        "feature_anti_spam": "🛡 Anti-spam filter",
+        "feature_anti_spam_desc": (
+            "🛡 *Anti-spam filter*\n"
+            "Automatically blocks suspicious sign-ups, repeated requests, and flood attempts to keep your bot clean."
+        ),
+        "feature_assistant_management": "🤝 Assistant management",
+        "feature_assistant_management_desc": (
+            "🤝 *Assistant management*\n"
+            "Add or remove assistant accounts, assign roles, and delegate daily operations without sharing your main credentials."
+        ),
+        "feature_user_levels": "🎚 User levels",
+        "feature_user_levels_desc": (
+            "🎚 *User levels*\n"
+            "Segment shoppers into tiers, unlock special pricing or rewards, and track loyalty progress automatically."
+        ),
+        "feature_stock_notifications": "🔔 Stock notifications",
+        "feature_stock_notifications_desc": (
+            "🔔 *Stock notifications*\n"
+            "Alert users when items are back in stock or running low so they never miss a drop."
+        ),
         "coming_soon": "🚧 *This feature is disabled for now.*",
         "rdp_choose_package": "🖥 *Choose your RDP package:*",
         "rdp_1m": "1️⃣ 1 Month ({price} {cur})",
@@ -153,6 +195,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Язык",
         "purchase_title": "🛍️ *Выберите пакет:*",
         "purchase_template": "📦 Шаблон-бот ({price} {cur})",
+        "purchase_semi": "⚡ Бот с частичным сервисом ({price} {cur})",
         "purchase_full": "🚀 Полный сервис-бот ({price} {cur})",
         "desc_template": (
             "🟢 *Шаблон-бот*\n"
@@ -162,6 +205,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Промокоды*\n"
             "• 📣 *Рассылки*\n"
             "• 👥 *Статистика и управление пользователями*\n\n"
+            "🕘 *Работает 24/7 без доп. оплат* (хостинг: 10 EUR/мес)."
+        ),
+        "desc_semi": (
+            "🟡 *Бот с частичным сервисом*\n"
+            "• ⚙️ *Меняйте функции в реальном времени*\n"
+            "• 🔄 *Регулярные обновления включены*\n"
+            "• ➕ *Добавление одной новой функции каждый месяц*\n"
+            "• 📊 *Расширенные инструменты управления*\n\n"
             "🕘 *Работает 24/7 без доп. оплат* (хостинг: 10 EUR/мес)."
         ),
         "desc_full": (
@@ -187,7 +238,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Оплатить с баланса",
         "insufficient_balance": "❌ Недостаточно средств. Пополните баланс.",
         "purchase_success": "✅ Оплата получена! Перейдите в *Настройки*, чтобы настроить бота.",
-        "purchase_unavailable": "✅ Вы уже приобрели полный пакет.",
+        "purchase_unavailable": "✅ Этот пакет уже приобретён или у вас есть более высокий уровень.",
         "config_first_time": (
             "🎉 *Добро пожаловать в настройки!*\n"
             "Вы здесь впервые. Нажмите *Настроить*, чтобы сконфигурировать бота или обратитесь в поддержку."
@@ -196,7 +247,46 @@ T: Dict[str, Dict[str, str]] = {
         "config_no_status": "🛑 *Чтобы получить доступ к настройкам, сначала приобретите бота.*",
         "config_setup": "🛠 Настроить",
         "config_rdp": "🖥 RDP",
+        "config_functions": "🧩 Функции",
         "config_support": "🆘 Поддержка",
+        "functions_title": "🧩 *Выберите категорию функций:*",
+        "functions_protection": "🛡 Защита и утилиты",
+        "functions_admin": "🧑‍💼 Функции для админа",
+        "functions_user": "👥 Функции для пользователей",
+        "functions_payments": "💳 Платежи",
+        "functions_protection_desc": "🛡 *Защита и утилиты*\nВыберите инструмент ниже, чтобы узнать подробности.",
+        "functions_admin_desc": (
+            "🧑‍💼 *Функции для админа*\n"
+            "Нажмите на пункт, чтобы узнать, как он помогает управлять магазином."
+        ),
+        "functions_user_desc": (
+            "👥 *Функции для пользователей*\n"
+            "Выберите функцию, чтобы увидеть улучшения для клиентов."
+        ),
+        "functions_payments_desc": (
+            "💳 *Платежи*\n"
+            "Принимайте безопасные криптоплатежи через NOWPayments с авто-подтверждением для SOL, USDT-TRC20 и XMR."
+        ),
+        "feature_anti_spam": "🛡 Антиспам-фильтр",
+        "feature_anti_spam_desc": (
+            "🛡 *Антиспам-фильтр*\n"
+            "Автоматически блокирует подозрительные регистрации, повторные запросы и флуд, чтобы бот оставался чистым."
+        ),
+        "feature_assistant_management": "🤝 Управление ассистентами",
+        "feature_assistant_management_desc": (
+            "🤝 *Управление ассистентами*\n"
+            "Добавляйте или удаляйте аккаунты помощников, назначайте роли и делегируйте задачи без передачи основных данных."
+        ),
+        "feature_user_levels": "🎚 Уровни пользователей",
+        "feature_user_levels_desc": (
+            "🎚 *Уровни пользователей*\n"
+            "Разделяйте покупателей на уровни, открывайте специальные цены и автоматически отслеживайте лояльность."
+        ),
+        "feature_stock_notifications": "🔔 Уведомления о наличии",
+        "feature_stock_notifications_desc": (
+            "🔔 *Уведомления о наличии*\n"
+            "Сообщайте пользователям, когда товары появляются снова или заканчиваются, чтобы они не пропускали новинки."
+        ),
         "coming_soon": "🚧 *Эта функция отключена.*",
         "rdp_choose_package": "🖥 *Выберите пакет RDP:*",
         "rdp_1m": "1️⃣ 1 месяц ({price} {cur})",
@@ -290,6 +380,7 @@ T: Dict[str, Dict[str, str]] = {
         "menu_language": "🌐 Kalba",
         "purchase_title": "🛍️ *Pasirinkite paketą:*",
         "purchase_template": "📦 Šabloninis botas ({price} {cur})",
+        "purchase_semi": "⚡ Dalinio aptarnavimo botas ({price} {cur})",
         "purchase_full": "🚀 Pilno aptarnavimo botas ({price} {cur})",
         "desc_template": (
             "🟢 *Šabloninis botas*\n"
@@ -299,6 +390,14 @@ T: Dict[str, Dict[str, str]] = {
             "• 🗒 *Nuolaidų kodai*\n"
             "• 📣 *Masiniai pranešimai*\n"
             "• 👥 *Vartotojų statistika ir valdymas*\n\n"
+            "🕘 *Veikia 24/7 be papildomų mokesčių* (hostingas: 10 EUR/mėn)."
+        ),
+        "desc_semi": (
+            "🟡 *Dalinio aptarnavimo botas*\n"
+            "• ⚙️ *Keiskite funkcijas realiu laiku*\n"
+            "• 🔄 *Reguliarūs atnaujinimai įskaičiuoti*\n"
+            "• ➕ *Kiekvieną mėnesį pridėkite po vieną naują funkciją*\n"
+            "• 📊 *Pažangūs parduotuvės įrankiai*\n\n"
             "🕘 *Veikia 24/7 be papildomų mokesčių* (hostingas: 10 EUR/mėn)."
         ),
         "desc_full": (
@@ -324,7 +423,7 @@ T: Dict[str, Dict[str, str]] = {
         "pay_with_balance": "💳 Mokėti iš balanso",
         "insufficient_balance": "❌ Nepakanka lėšų. Papildykite balansą.",
         "purchase_success": "✅ Mokėjimas gautas! Eikite į *Nustatymai* ir sukonfigūruokite botą.",
-        "purchase_unavailable": "✅ Jau turite pilną paketą.",
+        "purchase_unavailable": "✅ Jūs jau turite šį paketą arba aukštesnį lygį.",
         "config_first_time": (
             "🎉 *Sveiki atvykę į nustatymus!*\n"
             "Jūs čia pirmą kartą. Paspauskite *Nustatyti*, kad sukonfigūruotumėte botą arba susisiekite su pagalba."
@@ -333,7 +432,46 @@ T: Dict[str, Dict[str, str]] = {
         "config_no_status": "🛑 *Norėdami pasiekti nustatymus, pirmiausia įsigykite botą.*",
         "config_setup": "🛠 Nustatyti",
         "config_rdp": "🖥 RDP",
+        "config_functions": "🧩 Funkcijos",
         "config_support": "🆘 Pagalba",
+        "functions_title": "🧩 *Pasirinkite funkcijų kategoriją:*",
+        "functions_protection": "🛡 Apsauga ir įrankiai",
+        "functions_admin": "🧑‍💼 Administratoriaus funkcijos",
+        "functions_user": "👥 Vartotojo funkcijos",
+        "functions_payments": "💳 Mokėjimai",
+        "functions_protection_desc": "🛡 *Apsauga ir įrankiai*\nPasirinkite įrankį ir sužinokite daugiau.",
+        "functions_admin_desc": (
+            "🧑‍💼 *Administratoriaus funkcijos*\n"
+            "Bakstelėkite punktą ir sužinokite, kaip jis padeda valdyti parduotuvę."
+        ),
+        "functions_user_desc": (
+            "👥 *Vartotojo funkcijos*\n"
+            "Pasirinkite funkciją ir pažiūrėkite, kokią patirtį gauna klientai."
+        ),
+        "functions_payments_desc": (
+            "💳 *Mokėjimai*\n"
+            "Priimkite saugius kriptomokėjimus per NOWPayments su automatiniu SOL, USDT-TRC20 ir XMR patvirtinimu."
+        ),
+        "feature_anti_spam": "🛡 Anti-spamo filtras",
+        "feature_anti_spam_desc": (
+            "🛡 *Anti-spamo filtras*\n"
+            "Automatiškai blokuoja įtartinus prisijungimus, pasikartojančias užklausas ir flood'ą, kad bot'as liktų švarus."
+        ),
+        "feature_assistant_management": "🤝 Asistentų valdymas",
+        "feature_assistant_management_desc": (
+            "🤝 *Asistentų valdymas*\n"
+            "Pridėkite ar pašalinkite asistentų paskyras, priskirkite roles ir deleguokite darbus neatskleisdami pagrindinių prisijungimų."
+        ),
+        "feature_user_levels": "🎚 Vartotojų lygiai",
+        "feature_user_levels_desc": (
+            "🎚 *Vartotojų lygiai*\n"
+            "Skirstykite pirkėjus į lygius, suteikite specialias kainas ir automatiškai sekite lojalumą."
+        ),
+        "feature_stock_notifications": "🔔 Atsargų pranešimai",
+        "feature_stock_notifications_desc": (
+            "🔔 *Atsargų pranešimai*\n"
+            "Praneškite vartotojams, kai prekės grįžta į sandėlį arba baigiasi, kad jie nepraleistų pasiūlymų."
+        ),
         "coming_soon": "🚧 *Ši funkcija išjungta.*",
         "rdp_choose_package": "🖥 *Pasirinkite RDP paketą:*",
         "rdp_1m": "1️⃣ 1 mėn. ({price} {cur})",


### PR DESCRIPTION
## Summary
- add a Functions entry to the config menu with nested keyboards for protection, admin, user, and payment categories
- implement callbacks that show detailed descriptions for anti-spam, assistant management, user levels, and stock notification features
- localize the new menu labels and feature descriptions in English, Russian, and Lithuanian

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d86d3ed7608332821e6e1b5dfe061d